### PR TITLE
Migration to meet new DNS requirements

### DIFF
--- a/v2rayN/dns_singbox_normal
+++ b/v2rayN/dns_singbox_normal
@@ -2,19 +2,14 @@
   "servers": [
     {
       "tag": "remote",
-      "address": "8.8.8.8",
-      "strategy": "prefer_ipv4",
+      "server": "8.8.8.8",
+      "type": "udp",
       "detour": "proxy"
     },
     {
       "tag": "local",
-      "address": "77.88.8.8",
-      "strategy": "prefer_ipv4",
-      "detour": "direct"
-    },
-    {
-      "tag": "block",
-      "address": "rcode://success"
+      "server": "77.88.8.8",
+      "type": "udp"
     }
   ],
   "rules": [
@@ -22,7 +17,8 @@
       "rule_set": [
         "geosite-category-ads-all"
       ],
-      "server": "block"
+      "action": "predefined",
+      "rcode": "NOERROR"
     }
   ],
   "final": "remote"

--- a/v2rayN/tun_singbox_dns
+++ b/v2rayN/tun_singbox_dns
@@ -2,19 +2,14 @@
   "servers": [
     {
       "tag": "remote",
-      "address": "8.8.8.8",
-      "strategy": "prefer_ipv4",
+      "server": "8.8.8.8",
+      "type": "udp",
       "detour": "proxy"
     },
     {
       "tag": "local",
-      "address": "77.88.8.8",
-      "strategy": "prefer_ipv4",
-      "detour": "direct"
-    },
-    {
-      "tag": "block",
-      "address": "rcode://success"
+      "server": "77.88.8.8",
+      "type": "udp"
     }
   ],
   "rules": [
@@ -22,7 +17,8 @@
       "rule_set": [
         "geosite-category-ads-all"
       ],
-      "server": "block"
+      "action": "predefined",
+      "rcode": "NOERROR"
     }
   ],
   "final": "remote"


### PR DESCRIPTION
Ссылка на документацию по миграции: https://sing-box.sagernet.org/migration/#__tabbed_1_12
Пожалуйста, убедитесь что мой вариант использования rcode в нынешней реализации верен.
В local убарн detour из-за отсутствия в нём необходимости(https://github.com/SagerNet/sing-box/issues/3585#issuecomment-3716521142).
Связано с проблемой: https://github.com/runetfreedom/russia-v2ray-custom-routing-list/issues/6