### PR TITLE
Add simple dns support

### DIFF
--- a/v2rayN/simple_dns.json
+++ b/v2rayN/simple_dns.json
@@ -1,0 +1,16 @@
+{
+  "UseSystemHosts": false,
+  "AddCommonHosts": true,
+  "FakeIP": false,
+  "GlobalFakeIp": true,
+  "BlockBindingQuery": true,
+  "DirectDNS": "77.88.8.8",
+  "RemoteDNS": "8.8.8.8,https://dns.google/dns-query,1.1.1.1",
+  "BootstrapDNS": "77.88.8.8",
+  "Strategy4Freedom": "",
+  "Strategy4Proxy": "",
+  "ServeStale": false,
+  "ParallelQuery": false,
+  "Hosts": "",
+  "DirectExpectedIPs": null
+}


### PR DESCRIPTION
I’m the primary contributor and maintainer of the Simple DNS feature in v2rayN. This PR adds the Simple DNS configuration for the Russia region.

Simple DNS differs from the current custom DNS format: the DNS configuration is generated by v2rayN itself and will automatically produce the appropriate DNS rules based on the active rule sets.

The other fields in this configuration are the default values that v2rayN applies on first run.