### PR TITLE
Add geosite:ru-available-only-inside to all_except_ru Russia-direct rule

### DIFF
--- a/v2rayN/all_except_ru.json
+++ b/v2rayN/all_except_ru.json
@@ -38,6 +38,9 @@
     "ip":[
       "geoip:ru"
     ],
+    "domain":[
+      "geosite:ru-available-only-inside"
+    ],
     "enabled":true,
     "remarks":"\u0414\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0435 \u0442\u043E\u043B\u044C\u043A\u043E \u0432 \u0420\u043E\u0441\u0441\u0438\u0438 \u043D\u0430\u043F\u0440\u044F\u043C\u0443\u044E"
   },


### PR DESCRIPTION
## Summary
Updates **“Доступные только в России напрямую”** routing rule in `v2rayN/all_except_ru.json`
Previously this rule only matched Russian traffic via **`geoip:ru`**. Domains that are available **only inside Russia** but may resolve to non-RU IPs, or resolve uncorrectly could miss that match.

## Change
- Added **`geosite:ru-available-only-inside`** under a `domain` list on the same outbound rule (`direct`), alongside the existing **`geoip:ru`** IP match.

